### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tinted-theming/builder-elixir

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017 Omar Bahareth
+Copyright (c) 2022 [Tinted Theming](https://github.com/tinted-theming)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # base16-builder-elixir
 [![CircleCI](https://circleci.com/gh/obahareth/base16-builder-elixir.svg?style=svg)](https://circleci.com/gh/obahareth/base16-builder-elixir)
 
-This is a base16 builder written in Elixir as defined by the [base16 builder guidelines](https://github.com/chriskempson/base16/blob/39d01a0248c7b28863ebafca66d7e1f5ca867b13/builder.md) version 0.9.0
+This is a base16 builder written in Elixir as defined by the [base16 builder guidelines](https://github.com/tinted-theming/home/blob/cc34890294402b9052b528e107f5b6b5ae15fdff/builder.md) version 0.9.0
 
 
 ## Usage Requirements
@@ -35,7 +35,7 @@ base16_builder
 
 Acquires git repositories containing templates and schemes to build base16
 themes as defined in the builder guidelines:
-https://github.com/chriskempson/base16/blob/master/builder.md
+https://github.com/tinted-theming/home/blob/main/builder.md
 
 
 Usage:


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

- Update references to base16-project
- Update the license
- Add github CODEOWNERS to auto assign repo maintainers to issues and PRs